### PR TITLE
Revert "Bump activesupport from 6.0.3.4 to 6.0.6.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.6.1)
+    activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -16,7 +16,7 @@ GEM
     colorator (1.1.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.1.7)
     dnsruby (1.61.5)
       simpleidn (~> 0.1)
     dotenv (2.7.6)
@@ -211,7 +211,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.17.0)
+    minitest (5.14.3)
     multipart-post (2.1.1)
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
@@ -248,13 +248,13 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.11)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    zeitwerk (2.6.6)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Reverts barnsleygymnasticsclub/barnsleygymnasticsclub.github.io#18